### PR TITLE
Fix PHP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,14 @@ PHP uses the system supplied CURL library. Version 7.34.0 or later is required.
 
 To check PHP, in a shell on your **production system**, run:
 
-`$ php -r '$ch = curl_init(); curl_setopt($ch, CURLOPT_URL, "https://tlstest.paypal.com/"); print_r(curl_exec($ch));'`
+`$ php -r '$ch = curl_init(); curl_setopt($ch, CURLOPT_URL, "https://tlstest.paypal.com/"); var_dump(curl_exec($ch));'`
 
 - On success, `PayPal_Connection_OK` is printed.
-- On failure, a network error will be printed.
+- On failure, `bool(false)` will be printed.
+
+You can get the specific error with `curl_error($ch)`:
+
+`php -r '$ch = curl_init(); curl_setopt($ch, CURLOPT_URL, "https://tlstest.paypal.com/"); var_dump(curl_exec($ch)); var_dump(curl_error($ch));'`
 
 ### Python
 


### PR DESCRIPTION
`curl_exec` return `false` on failure. It does not print the error as indicated in the README

http://php.net/manual/en/function.curl-exec.php

Additionally, if you use `print_r()` you will not get any feedback (`var_dump` will tell you what you need...).

I've also added a note so that users can quickly find the actual error.

P.S. I love that this is on GitHub.