### PR TITLE
Update TlsCheck.php to force TLS 1.2

### DIFF
--- a/php/TlsCheck.php
+++ b/php/TlsCheck.php
@@ -5,6 +5,9 @@ $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, "https://tlstest.paypal.com/"); 
 curl_setopt($ch, CURLOPT_CAINFO, dirname(__FILE__) . '/cacert.pem');
 
+// Some environments may be capable of TLS 1.2 but it is not in their list of defaults so need the SSL version option to be set.
+curl_setopt($ch, CURLOPT_SSLVERSION, 6);
+
 curl_exec($ch);
 echo "\n";
 


### PR DESCRIPTION
Some PHP environments may be capable of TLS 1.2 but they may not use TLS 1.2 unless forced to. The PayPal PHP library already forces this action by default so for testing purposes, change the script to mirror this behavior. Address issue #18 